### PR TITLE
Fix the span position of the intersect operators

### DIFF
--- a/src/XLParser.Tests/FormulaAnalysisTest.cs
+++ b/src/XLParser.Tests/FormulaAnalysisTest.cs
@@ -129,6 +129,14 @@ namespace XLParser.Tests
             var functions = fa.Functions().Distinct().ToList();
             CollectionAssert.Contains(functions, "INTERSECT");
         }
+
+        [TestMethod]
+        public void IntersectIsAtCorrectPosition()
+        {
+            var fa = new FormulaAnalyzer("SUM(A1:A3 A2:A3)");
+            var intersect = fa.AllNodes.FirstOrDefault(node => node.Token?.Terminal?.Name == "INTERSECT");
+            Assert.AreEqual(9, intersect.Span.Location.Position);
+        }
         #endregion
 
         #region References()

--- a/src/XLParser/ExcelFormulaParser.cs
+++ b/src/XLParser/ExcelFormulaParser.cs
@@ -45,6 +45,15 @@ namespace XLParser
         public static ParseTree ParseToTree(string input)
         {
             var tree = p.Parse(input);
+            var intersects = tree.Root.AllNodes().Where(node => node.Token?.Terminal?.Name == "INTERSECT");
+
+            foreach (ParseTreeNode intersect in intersects)
+            {
+                int newPosition = intersect.Span.Location.Position - 1;
+                var newLocation = new SourceLocation(newPosition, intersect.Span.Location.Line, newPosition);
+
+                intersect.Span = new SourceSpan(newLocation, 1);
+            }
 
             if (tree.HasErrors())
             {


### PR DESCRIPTION
INTERSECT operators in Excel are spaces, which were treated specially in the parser. Its position has been modified after the fact to reflect the actual space character.